### PR TITLE
Fix savestate corruption bug

### DIFF
--- a/source/memory.c
+++ b/source/memory.c
@@ -2297,7 +2297,8 @@ uint32_t load_backup()
       // Could be either flash or SRAM, go with flash
       case 0x10000:
         backup_type = BACKUP_FLASH;
-        sram_size = FLASH_SIZE_64KB;
+        flash_size = FLASH_SIZE_64KB;
+        sram_size = SRAM_SIZE_64KB;
         break;
 
       case 0x20000:

--- a/source/memory.c
+++ b/source/memory.c
@@ -2698,6 +2698,10 @@ ssize_t load_gamepak(const char* file_path)
 
 		gamepak_size = (file_size + 0x7FFF) & ~0x7FFF;
 
+		sram_size = SRAM_SIZE_32KB;
+		flash_size = FLASH_SIZE_64KB;
+		eeprom_size = EEPROM_512_BYTE;
+
 		load_backup();
 
 		memcpy(gamepak_title, gamepak_rom + 0xA0, 12);
@@ -3741,14 +3745,8 @@ void init_memory()
   io_registers[REG_RCNT] = 0x0000;
   io_registers[REG_SIOCNT] = 0x0004;
 
-
-
-  sram_size = SRAM_SIZE_32KB;
-  flash_size = FLASH_SIZE_64KB;
-
   flash_bank_offset = 0;
   flash_command_position = 0;
-  eeprom_size = EEPROM_512_BYTE;
   eeprom_mode = EEPROM_BASE_MODE;
   eeprom_address = 0;
   eeprom_counter = 0;


### PR DESCRIPTION
Loading a 64 KiB FLASH savestate would properly init backup_type and
sram_size. But then the code loading game_config.txt would reset
unconditionally backup_type to BACKUP_NONE. When exiting the game
without saving, the emulator would overwrite the savestate file as
if it was a 32 KiB SRAM.

This set of two commits fix this behaviour.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>